### PR TITLE
feat: 청원, 회원, 관심목록 엔티티 간의 관계 연결

### DIFF
--- a/src/main/java/com/example/nbe2_2_team03/entity/Interest.java
+++ b/src/main/java/com/example/nbe2_2_team03/entity/Interest.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "interest")
+@ToString
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,8 +17,11 @@ public class Interest {
     @Column(name = "interest_id", nullable = false, unique = true)
     private Long interestId;
 
+    @ManyToOne
+    @JoinColumn(name = "petition_id", nullable = false)
+    private Petition petition;  // 청원 필드 추가. N:1 연결
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 }

--- a/src/main/java/com/example/nbe2_2_team03/entity/Member.java
+++ b/src/main/java/com/example/nbe2_2_team03/entity/Member.java
@@ -6,10 +6,12 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Table(name = "member")
+@ToString
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -46,7 +48,8 @@ public class Member {
     private LocalDateTime createdDate;
 
     @OneToMany(mappedBy = "member")
-    private List<Interest> interestList;
+    @Builder.Default
+    private List<Interest> interestList = new ArrayList<>();    // 객체 생성 시 빈 리스트 초기화
 
     @OneToMany(mappedBy = "member")
     private List<Inquiry> inquiryList;

--- a/src/main/java/com/example/nbe2_2_team03/entity/Petition.java
+++ b/src/main/java/com/example/nbe2_2_team03/entity/Petition.java
@@ -1,21 +1,9 @@
 package com.example.nbe2_2_team03.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "petition")
@@ -24,7 +12,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@EntityListeners(AuditingEntityListener.class)
 public class Petition {
 
     @Id
@@ -32,8 +19,9 @@ public class Petition {
     @Column(name = "petition_id")
     private Long petitionId;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @ManyToOne(fetch = FetchType.LAZY)  // Member 객체와 N:1 연결. 회원 삭제 시 청원도 삭제되는 cascade 논의 필요
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "title", nullable = false, length = 1000)    // 청원서 작성 시 제목 길이 제한 1000 Byte
     private String title;


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
Petition, Member, Interest 클래스의 필드 내 관계 연결

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. 기존 Petition의 Long memberId를 Member member로 수정하고, ManyToOne 설정
2. Member 객체 생성 시점에 interestList를 ArrayList로 초기화하여 NullPointerException 방지
3. Interest에 청원 필드 추가하고, ManyToOne 설정

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
관리자 회원을 삭제할 때, 해당 관리자가 작성한 Petition이 동시에 삭제될 지 논의 필요
- Petition.member 필드의 ManyToOne(cascade = CascadeType.ALL)
