### PR TITLE
feat: 1:1 문의 엔티티 생성 및 회원 엔티티 연결 #16

### DIFF
--- a/src/main/java/com/example/echo/domain/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/example/echo/domain/inquiry/entity/Inquiry.java
@@ -3,13 +3,19 @@ package com.example.echo.domain.inquiry.entity;
 import com.example.echo.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "inquiry")
+@ToString
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class Inquiry {
 
     @Id
@@ -17,13 +23,51 @@ public class Inquiry {
     @Column(name = "inquiry_id", nullable = false, unique = true)
     private Long inquiryId;
 
-    @Column(name = "inquiry_title", length = 255)
+    @ManyToOne(fetch = FetchType.LAZY)  // Member 객체와 N:1 연결
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inquiry_category", nullable = false)
+    private InquiryCategory inquiryCategory;
+
+    @Column(name = "inquiry_title", nullable = false)
     private String inquiryTitle;
 
-    @Column(name = "inquiry_content", length = 2000)
+    @Column(name = "inquiry_content", length = 2000, nullable = false)
     private String inquiryContent;
 
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @CreatedDate
+    @Column(name = "created_date", nullable = false, updatable = false)
+    private LocalDateTime createdDate;
+
+    @Column(name = "reply_content", length = 2000)  // 문의 등록 시 관리자 답변 null
+    private String replyContent;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "inquiry_status", nullable = false)
+    @Builder.Default
+    private InquiryStatus inquiryStatus = InquiryStatus.PENDING;    // 문의 등록 시 "답변 대기 중" 기본값
+
+    @Column(name = "replied_date")
+    private LocalDateTime repliedDate;  // 관리자가 답변 시 changeReplyContent()를 통해 갱신
+
+    public void changeInquiryCategory(InquiryCategory inquiryCategory) {
+        this.inquiryCategory = inquiryCategory;
+    }
+
+    public void changeInquiryTitle(String inquiryTitle) {
+        this.inquiryTitle = inquiryTitle;
+    }
+
+    public void changeInquiryContent(String inquiryContent) {
+        this.inquiryContent = inquiryContent;
+    }
+
+    // 관리자 답변 내용 추가/수정 메서드. 답변 시점에 답변 상태와 답변 작성일 갱신
+    public void changeReplyContent(String replyContent) {
+        this.replyContent = replyContent;
+        this.inquiryStatus = InquiryStatus.RESOLVED;
+        this.repliedDate = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/echo/domain/inquiry/entity/InquiryCategory.java
+++ b/src/main/java/com/example/echo/domain/inquiry/entity/InquiryCategory.java
@@ -1,0 +1,15 @@
+package com.example.echo.domain.inquiry.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum InquiryCategory {
+
+    MEMBER("회원정보"),
+    PETITION("청원"),
+    OTHERS("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/example/echo/domain/inquiry/entity/InquiryStatus.java
+++ b/src/main/java/com/example/echo/domain/inquiry/entity/InquiryStatus.java
@@ -1,0 +1,14 @@
+package com.example.echo.domain.inquiry.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum InquiryStatus {
+
+    PENDING("답변대기중"),
+    RESOLVED("답변완료");
+
+    private final String description;
+}

--- a/src/main/java/com/example/echo/domain/member/entity/Member.java
+++ b/src/main/java/com/example/echo/domain/member/entity/Member.java
@@ -57,5 +57,10 @@ public class Member {
     private List<Interest> interestList = new ArrayList<>();    // 객체 생성 시 빈 리스트 초기화
 
     @OneToMany(mappedBy = "member")
-    private List<Inquiry> inquiryList;
+    @Builder.Default
+    private List<Inquiry> inquiryList = new ArrayList<>();      // Member 객체 생성 시 1:1 문의 비어 있는 리스트 초기화
+
+    public void addInquiry(Inquiry inquiry) {
+        inquiryList.add(inquiry);
+    }
 }


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
1:1 문의 엔티티 생성 및 회원 엔티티 연결 

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. Member 객체 생성 시 1:1 문의 비어 있는 리스트 초기화
2. 1:1 문의 유형과 상태 열거형 추가
    - InquiryCategory에 문의 유형을 세 가지로 분할. "회원정보", "청원", "기타" 
    - InquiryStatus에 문의 상태를 두 가지로 분할. "답변대기중", "답변완료". 문의 등록 시 기본 상태를 "답변대기중" 설정.
3. Inquiry 필드 추가 
    - 사용자 문의 수정 메서드와 관리자 문의 답변 메서드 추가
    - 관리자 답변 시 답변 상태와 답변 작성일 동시에 갱신.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
