### PR TITLE
feat: 회원 1:1 문의 등록/조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,14 @@ repositories {
 }
 
 dependencies {
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta' // QueryDSL JPA 의존성
+	annotationProcessor(
+			'jakarta.persistence:jakarta.persistence-api',
+			'jakarta.annotation:jakarta.annotation-api',
+			'com.querydsl:querydsl-apt:5.1.0:jakarta',
+			'org.projectlombok:lombok'
+	)
+
 	implementation 'net.coobird:thumbnailator:0.4.20'
 
 	implementation 'org.seleniumhq.selenium:selenium-java:4.19.1'
@@ -35,7 +43,6 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/example/echo/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/example/echo/domain/inquiry/controller/InquiryController.java
@@ -1,0 +1,27 @@
+package com.example.echo.domain.inquiry.controller;
+
+import com.example.echo.domain.inquiry.dto.request.InquiryRequestDTO;
+import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
+import com.example.echo.domain.inquiry.service.InquiryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    // USER 회원 1:1 문의 등록
+    @PostMapping
+    public ResponseEntity<InquiryResponseDTO> registerInquiry(@RequestBody InquiryRequestDTO inquiryRequestDTO) {
+        InquiryResponseDTO registeredInquiry = inquiryService.createInquiry(inquiryRequestDTO);
+        return ResponseEntity.ok(registeredInquiry);
+    }
+}
+

--- a/src/main/java/com/example/echo/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/example/echo/domain/inquiry/controller/InquiryController.java
@@ -5,10 +5,7 @@ import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
 import com.example.echo.domain.inquiry.service.InquiryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/inquiries")
@@ -23,5 +20,16 @@ public class InquiryController {
         InquiryResponseDTO registeredInquiry = inquiryService.createInquiry(inquiryRequestDTO);
         return ResponseEntity.ok(registeredInquiry);
     }
+
+    // 모든 회원 1:1 문의 단건 조회
+    @GetMapping("/{inquiryId}")
+    public ResponseEntity<InquiryResponseDTO> getInquiry(@PathVariable Long inquiryId) {
+        InquiryResponseDTO foundInquiry = inquiryService.getInquiryById(inquiryId);
+        return ResponseEntity.ok(foundInquiry);
+    }
+
+    // ADMIN 회원 모든 1:1 문의 전체 리스트 조회
+
+    // USER 회원 본인이 등록한 1:1 문의 전체 리스트 조회
 }
 

--- a/src/main/java/com/example/echo/domain/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/example/echo/domain/inquiry/controller/InquiryController.java
@@ -1,9 +1,11 @@
 package com.example.echo.domain.inquiry.controller;
 
+import com.example.echo.domain.inquiry.dto.request.InquiryPageRequestDTO;
 import com.example.echo.domain.inquiry.dto.request.InquiryRequestDTO;
 import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
 import com.example.echo.domain.inquiry.service.InquiryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,8 +30,13 @@ public class InquiryController {
         return ResponseEntity.ok(foundInquiry);
     }
 
-    // ADMIN 회원 모든 1:1 문의 전체 리스트 조회
-
-    // USER 회원 본인이 등록한 1:1 문의 전체 리스트 조회
+    // ADMIN/USER 회원 종류에 따른 모든 1:1 문의 전체 리스트 조회
+    @GetMapping
+    public ResponseEntity<Page<InquiryResponseDTO>> getAllInquiries(
+            @RequestParam Long memberId,    // 임시 url 부여. 로그인 기능 추가 시 Authentication으로 대체
+            @ModelAttribute InquiryPageRequestDTO inquiryPageRequestDTO) {
+        Page<InquiryResponseDTO> inquiriesPage = inquiryService.getInquiriesByMemberRole(memberId, inquiryPageRequestDTO);
+        return ResponseEntity.ok(inquiriesPage);
+    }
 }
 

--- a/src/main/java/com/example/echo/domain/inquiry/dto/request/InquiryPageRequestDTO.java
+++ b/src/main/java/com/example/echo/domain/inquiry/dto/request/InquiryPageRequestDTO.java
@@ -1,0 +1,36 @@
+package com.example.echo.domain.inquiry.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InquiryPageRequestDTO {
+
+    @NotNull(message = "페이지 번호는 필수입니다.")
+    @Min(value = 1, message = "페이지 번호는 최소 1이어야 합니다.")
+    @Builder.Default
+    private Integer pageNumber = 1;
+
+    @NotNull(message = "페이지 사이즈는 필수입니다.")
+    @Min(value = 5, message = "페이지 사이즈는 최소 5이어야 합니다.")
+    @Max(value = 20, message = "페이지 사이즈는 최대 20이어야 합니다.")
+    @Builder.Default
+    private Integer pageSize = 5;
+
+    public PageRequest getPageable() {
+        return PageRequest.of(
+                pageNumber - 1,
+                pageSize,
+                Sort.by("inquiryId").descending()); // 항상 최신 순 정려
+    }
+}

--- a/src/main/java/com/example/echo/domain/inquiry/dto/request/InquiryRequestDTO.java
+++ b/src/main/java/com/example/echo/domain/inquiry/dto/request/InquiryRequestDTO.java
@@ -1,0 +1,30 @@
+package com.example.echo.domain.inquiry.dto.request;
+
+import com.example.echo.domain.inquiry.entity.Inquiry;
+import com.example.echo.domain.inquiry.entity.InquiryCategory;
+import com.example.echo.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryRequestDTO {
+
+    private Long memberId;
+    private InquiryCategory inquiryCategory;
+    private String inquiryTitle;
+    private String inquiryContent;
+
+    public Inquiry toEntity(Member member) {
+        return Inquiry.builder()
+                .member(member)
+                .inquiryCategory(inquiryCategory)
+                .inquiryTitle(inquiryTitle)
+                .inquiryContent(inquiryContent)
+                .build();
+    }
+}

--- a/src/main/java/com/example/echo/domain/inquiry/dto/response/InquiryResponseDTO.java
+++ b/src/main/java/com/example/echo/domain/inquiry/dto/response/InquiryResponseDTO.java
@@ -1,0 +1,43 @@
+package com.example.echo.domain.inquiry.dto.response;
+
+import com.example.echo.domain.inquiry.entity.Inquiry;
+import com.example.echo.domain.inquiry.entity.InquiryCategory;
+import com.example.echo.domain.inquiry.entity.InquiryStatus;
+import com.example.echo.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InquiryResponseDTO {
+
+    private Long inquiryId;
+    private Long memberId;
+    private InquiryCategory inquiryCategory;
+    private String inquiryTitle;
+    private String inquiryContent;
+    private LocalDateTime createdDate;
+    private String replyContent;
+    private InquiryStatus inquiryStatus;
+    private LocalDateTime repliedDate;
+
+    public static InquiryResponseDTO from(Inquiry inquiry) {
+        return InquiryResponseDTO.builder()
+                .inquiryId(inquiry.getInquiryId())
+                .memberId(inquiry.getMember().getMemberId())
+                .inquiryCategory(inquiry.getInquiryCategory())
+                .inquiryTitle(inquiry.getInquiryTitle())
+                .inquiryContent(inquiry.getInquiryContent())
+                .createdDate(inquiry.getCreatedDate())
+                .replyContent(inquiry.getReplyContent())
+                .inquiryStatus(inquiry.getInquiryStatus())
+                .repliedDate(inquiry.getRepliedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/echo/domain/inquiry/dto/response/InquiryResponseDTO.java
+++ b/src/main/java/com/example/echo/domain/inquiry/dto/response/InquiryResponseDTO.java
@@ -3,7 +3,6 @@ package com.example.echo.domain.inquiry.dto.response;
 import com.example.echo.domain.inquiry.entity.Inquiry;
 import com.example.echo.domain.inquiry.entity.InquiryCategory;
 import com.example.echo.domain.inquiry.entity.InquiryStatus;
-import com.example.echo.domain.member.entity.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/example/echo/domain/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/example/echo/domain/inquiry/entity/Inquiry.java
@@ -2,7 +2,10 @@ package com.example.echo.domain.inquiry.entity;
 
 import com.example.echo.domain.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 

--- a/src/main/java/com/example/echo/domain/inquiry/repository/InquiryPaging.java
+++ b/src/main/java/com/example/echo/domain/inquiry/repository/InquiryPaging.java
@@ -1,0 +1,11 @@
+package com.example.echo.domain.inquiry.repository;
+
+import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface InquiryPaging {
+
+    // USER 회원의 본인이 등록한 1:1 문의 리스트 페이징
+    Page<InquiryResponseDTO> findAllInquiriesUser(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/example/echo/domain/inquiry/repository/InquiryPagingImpl.java
+++ b/src/main/java/com/example/echo/domain/inquiry/repository/InquiryPagingImpl.java
@@ -1,0 +1,51 @@
+package com.example.echo.domain.inquiry.repository;
+
+import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
+import com.example.echo.domain.inquiry.entity.Inquiry;
+import com.example.echo.domain.inquiry.entity.QInquiry;
+import com.example.echo.domain.member.entity.QMember;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public class InquiryPagingImpl extends QuerydslRepositorySupport implements InquiryPaging {
+
+    public InquiryPagingImpl() {
+        super(Inquiry.class);
+    }
+
+    @Override
+    public Page<InquiryResponseDTO> findAllInquiriesUser(@Param("memberId") Long memberId, Pageable pageable) {
+        QInquiry inquiry = QInquiry.inquiry;
+        QMember member = QMember.member;
+
+        // Inquiry와 Member를 left join하고 memberId로 필터링
+        JPQLQuery<InquiryResponseDTO> query = from(inquiry)
+                .leftJoin(inquiry.member, member)
+                .where(member.memberId.eq(memberId))
+                .select(Projections.bean(InquiryResponseDTO.class,  // 프로젝션
+                        inquiry.inquiryId,
+                        member.memberId.as("memberId"),
+                        inquiry.inquiryCategory,
+                        inquiry.inquiryTitle,
+                        inquiry.inquiryContent,
+                        inquiry.createdDate,
+                        inquiry.replyContent,
+                        inquiry.inquiryStatus,
+                        inquiry.repliedDate
+                ));
+
+        getQuerydsl().applyPagination(pageable, query);  // 페이징 적용
+
+        List<InquiryResponseDTO> content = query.fetch();    // 쿼리 실행 결과
+        long total = query.fetchCount(); // 총 개수
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/src/main/java/com/example/echo/domain/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/example/echo/domain/inquiry/repository/InquiryRepository.java
@@ -1,7 +1,15 @@
 package com.example.echo.domain.inquiry.repository;
 
+import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
 import com.example.echo.domain.inquiry.entity.Inquiry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+public interface InquiryRepository extends JpaRepository<Inquiry, Long>, InquiryPaging {
+
+    // ADMIN 회원의 모든 1:1 문의 리스트 페이징
+    @Query("select i from Inquiry i join fetch i.member im")
+    Page<InquiryResponseDTO> findAllInquiriesAdmin(Pageable pageable);
 }

--- a/src/main/java/com/example/echo/domain/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/example/echo/domain/inquiry/repository/InquiryRepository.java
@@ -1,0 +1,7 @@
+package com.example.echo.domain.inquiry.repository;
+
+import com.example.echo.domain.inquiry.entity.Inquiry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+}

--- a/src/main/java/com/example/echo/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/example/echo/domain/inquiry/service/InquiryService.java
@@ -24,4 +24,16 @@ public class InquiryService {
         Inquiry savedInquiry = inquiryRepository.save(createdInquiry);
         return InquiryResponseDTO.from(savedInquiry);
     }
+
+    // 모든 회원 1:1 문의 단건 조회
+    public InquiryResponseDTO getInquiryById(Long inquiryId) {
+        Inquiry foundInquiry = findInquiryById(inquiryId);
+        return InquiryResponseDTO.from(foundInquiry);
+    }
+
+    // 문의 ID로 문의 조회
+    private Inquiry findInquiryById(Long inquiryId) {
+        return inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new RuntimeException("1:1 문의 정보를 찾을 수 없습니다."));
+    }
 }

--- a/src/main/java/com/example/echo/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/example/echo/domain/inquiry/service/InquiryService.java
@@ -1,13 +1,18 @@
 package com.example.echo.domain.inquiry.service;
 
+import com.example.echo.domain.inquiry.dto.request.InquiryPageRequestDTO;
 import com.example.echo.domain.inquiry.dto.request.InquiryRequestDTO;
 import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
 import com.example.echo.domain.inquiry.entity.Inquiry;
 import com.example.echo.domain.inquiry.repository.InquiryRepository;
+import com.example.echo.domain.member.dto.MemberDto;
 import com.example.echo.domain.member.entity.Member;
+import com.example.echo.domain.member.entity.Role;
 import com.example.echo.domain.member.service.MemberService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,9 +36,30 @@ public class InquiryService {
         return InquiryResponseDTO.from(foundInquiry);
     }
 
+    // ADMIN/USER 회원 종류에 따른 1:1 문의 전체 리스트 조회
+    public Page<InquiryResponseDTO> getInquiriesByMemberRole(Long memberId, InquiryPageRequestDTO inquiryPageRequestDTO) {
+        // memberId에 따라 해당 다르게 조회
+        MemberDto foundMember = memberService.getMember(memberId);
+        if (foundMember.getRole() == Role.ADMIN) {
+            return findAllForAdmin(inquiryPageRequestDTO.getPageable());    // ADMIN 모든 문의 조회
+        } else {
+            return findAllForUser(memberId, inquiryPageRequestDTO.getPageable());     // USER 개인 모든 문의 조회
+        }
+    }
+
     // 문의 ID로 문의 조회
     private Inquiry findInquiryById(Long inquiryId) {
         return inquiryRepository.findById(inquiryId)
                 .orElseThrow(() -> new RuntimeException("1:1 문의 정보를 찾을 수 없습니다."));
+    }
+
+    // ADMIN 모든 문의 조회
+    private Page<InquiryResponseDTO> findAllForAdmin(Pageable pageable) {
+        return inquiryRepository.findAllInquiriesAdmin(pageable);
+    }
+
+    // USER 본인 문의 조회
+    private Page<InquiryResponseDTO> findAllForUser(Long memberId, Pageable pageable) {
+        return inquiryRepository.findAllInquiriesUser(memberId, pageable);
     }
 }

--- a/src/main/java/com/example/echo/domain/inquiry/service/InquiryService.java
+++ b/src/main/java/com/example/echo/domain/inquiry/service/InquiryService.java
@@ -1,0 +1,27 @@
+package com.example.echo.domain.inquiry.service;
+
+import com.example.echo.domain.inquiry.dto.request.InquiryRequestDTO;
+import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
+import com.example.echo.domain.inquiry.entity.Inquiry;
+import com.example.echo.domain.inquiry.repository.InquiryRepository;
+import com.example.echo.domain.member.entity.Member;
+import com.example.echo.domain.member.service.MemberService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryService {
+
+    private final MemberService memberService;
+    private final InquiryRepository inquiryRepository;
+
+    @Transactional
+    public InquiryResponseDTO createInquiry(InquiryRequestDTO inquiryRequestDTO) {
+        Member foundMember = memberService.findMemberById(inquiryRequestDTO.getMemberId());    // memberId로 Member 엔티티를 조회
+        Inquiry createdInquiry = inquiryRequestDTO.toEntity(foundMember);   // 1:1 문의 생성
+        Inquiry savedInquiry = inquiryRepository.save(createdInquiry);
+        return InquiryResponseDTO.from(savedInquiry);
+    }
+}

--- a/src/main/java/com/example/echo/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/echo/domain/member/service/MemberService.java
@@ -29,14 +29,14 @@ public class MemberService {
     }
 
     //회원 조회
-    public MemberDto getMember(Long memberId){  // Long memberId로 변경
+    public MemberDto getMember(Long memberId) {  // Long memberId로 변경
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new RuntimeException("회원정보를 찾을수 없습니다."));
+                .orElseThrow(() -> new RuntimeException("회원정보를 찾을수 없습니다."));
         return MemberDto.of(member);
     }
 
     //전체 회원 조회
-    public List<MemberDto> getAllMembers(){
+    public List<MemberDto> getAllMembers() {
         return memberRepository.findAll().stream()
                 .map(MemberDto::of)
                 .collect(Collectors.toList());
@@ -44,9 +44,9 @@ public class MemberService {
 
     //회원 정보 수정
     @Transactional
-    public MemberDto updateMember(Long memberId, MemberDto memberDto){ // Long memberId로 변경
+    public MemberDto updateMember(Long memberId, MemberDto memberDto) { // Long memberId로 변경
         Member member = memberRepository.findById(memberId)
-            .orElseThrow(()-> new RuntimeException("회원정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new RuntimeException("회원정보를 찾을 수 없습니다."));
 
         member.setUserId(memberDto.getUserId()); // userId로 변경
         member.setName(memberDto.getName());
@@ -61,9 +61,9 @@ public class MemberService {
 
     //id로 회원 삭제
     @Transactional
-    public void deleteMember(Long memberId){ // Long memberId로 변경
+    public void deleteMember(Long memberId) { // Long memberId로 변경
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(()-> new RuntimeException("회원 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new RuntimeException("회원 정보를 찾을 수 없습니다."));
         memberRepository.delete(member);
     }
 
@@ -88,8 +88,8 @@ public class MemberService {
     }
 
     // 공통 메서드: 회원 ID로 회원 조회
-    private Member findMemberById(Long id) {
-        return memberRepository.findById(id)
+    public Member findMemberById(Long memberId) {   // InquiryService에서도 회원 객체를 직접 접근해야 해서 public 변경
+        return memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("회원정보를 찾을 수 없습니다."));
     }
 }

--- a/src/test/java/com/example/echo/domain/inquiry/repository/InquiryRepositoryTest.java
+++ b/src/test/java/com/example/echo/domain/inquiry/repository/InquiryRepositoryTest.java
@@ -1,0 +1,107 @@
+package com.example.echo.domain.inquiry.repository;
+
+import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
+import com.example.echo.domain.inquiry.entity.Inquiry;
+import com.example.echo.domain.inquiry.entity.InquiryCategory;
+import com.example.echo.domain.member.entity.Member;
+import com.example.echo.domain.member.entity.Role;
+import com.example.echo.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class InquiryRepositoryTest {
+
+    @Autowired
+    private InquiryRepository inquiryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("1:1 문의 저장")
+    void testSaveInquiry() throws Exception {
+        Member member = Member.builder()
+                .userId("member2")
+                .name("bbb")
+                .email("b@b.com")
+                .password("111")
+                .phone("010-1234-5678")
+                .avatarImage("bbb.png")
+                .role(Role.USER)
+                .build();
+        Member savedMember = memberRepository.save(member);
+        Inquiry inquiry = Inquiry.builder()
+                .member(savedMember)
+                .inquiryCategory(InquiryCategory.MEMBER)
+                .inquiryTitle("문의제목b")
+                .inquiryContent("문의내용b")
+                .build();
+
+        Inquiry savedInquiry = inquiryRepository.save(inquiry);
+
+        assertNotNull(savedInquiry);
+        System.out.println(savedInquiry);
+    }
+
+    @Test
+    @DisplayName("1:1 문의 1개 조회")
+    void testFindInquiry() throws Exception {
+        Long inquiryId = 1L;
+
+        Optional<Inquiry> foundInquiry = inquiryRepository.findById(inquiryId);
+
+        assertNotNull(foundInquiry);
+        assertEquals(1L, foundInquiry.get().getInquiryId());
+        System.out.println(foundInquiry);
+    }
+    
+    @Test
+    @DisplayName("ADMIN의 모든 1:1 문의 조회 페이징")
+    void testFindAllInquiriesAdmin() throws Exception {
+        // 1페이지 5사이즈 조회. DB엔 문의 데이터 총 8개 존재.
+        Pageable pageable = PageRequest.of(1, 5, Sort.by("inquiryId").descending());
+
+        Page<InquiryResponseDTO> inquiriesAdmin = inquiryRepository.findAllInquiriesAdmin(pageable);
+
+        assertNotNull(inquiriesAdmin);
+        assertEquals(8, inquiriesAdmin.getTotalElements());
+        assertEquals(2, inquiriesAdmin.getTotalPages());
+        assertEquals(1, inquiriesAdmin.getNumber());
+        assertEquals(5, inquiriesAdmin.getSize());
+        assertEquals(3, inquiriesAdmin.getContent().size());
+    }
+
+    @Test
+    @DisplayName("USER의 모든 1:1 문의 조회 페이징")
+    void testFindAllInquiriesUser() throws Exception {
+        // 1페이지 5사이즈 조회. DB엔 memberId = 1로 문의 데이터 총 7개 존재.
+        Long memberId = 1L;
+        Pageable pageable = PageRequest.of(1, 5, Sort.by("inquiryId").descending());
+
+        Page<InquiryResponseDTO> inquiriesUser = inquiryRepository.findAllInquiriesUser(memberId, pageable);
+
+        assertNotNull(inquiriesUser);
+        assertEquals(7, inquiriesUser.getTotalElements());
+        assertEquals(2, inquiriesUser.getTotalPages());
+        assertEquals(1, inquiriesUser.getNumber());
+        assertEquals(5, inquiriesUser.getSize());
+        assertEquals(2, inquiriesUser.getContent().size());
+    }
+}

--- a/src/test/java/com/example/echo/domain/inquiry/service/InquiryServiceTest.java
+++ b/src/test/java/com/example/echo/domain/inquiry/service/InquiryServiceTest.java
@@ -1,0 +1,103 @@
+package com.example.echo.domain.inquiry.service;
+
+import com.example.echo.domain.inquiry.dto.request.InquiryPageRequestDTO;
+import com.example.echo.domain.inquiry.dto.request.InquiryRequestDTO;
+import com.example.echo.domain.inquiry.dto.response.InquiryResponseDTO;
+import com.example.echo.domain.inquiry.entity.InquiryCategory;
+import com.example.echo.domain.member.entity.Member;
+import com.example.echo.domain.member.entity.Role;
+import com.example.echo.domain.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class InquiryServiceTest {
+
+    @Autowired
+    private InquiryService inquiryService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("1:1 문의 생성")
+    void testCreateInquiry() {
+        InquiryRequestDTO inquiryRequestDTO = InquiryRequestDTO.builder()
+                .memberId(1L)
+                .inquiryCategory(InquiryCategory.MEMBER)
+                .inquiryTitle("문의제목11")
+                .inquiryContent("문의내용11")
+                .build();
+
+        InquiryResponseDTO createdInquiry = inquiryService.createInquiry(inquiryRequestDTO);
+
+        assertNotNull(createdInquiry);
+        System.out.println(createdInquiry);
+    }
+
+    @Test
+    @DisplayName("모든 회원 1:1 문의 상세 조회")
+    void testGetInquiryById() {
+        Long inquiryId = 1L;
+
+        // 정상 조회
+        InquiryResponseDTO foundInquiry = inquiryService.getInquiryById(inquiryId);
+        assertNotNull(foundInquiry);
+
+        // 예외 발생 테스트
+        assertEquals("1:1 문의 정보를 찾을 수 없습니다.",
+                assertThrows(RuntimeException.class, () ->
+                        inquiryService.getInquiryById(100L)
+                ).getMessage()
+        );
+    }
+
+    @Test
+    @DisplayName("ADMIN 1:1 문의 전체 조회")
+    void testFindAllForAdmin() throws Exception {
+        // 2페이지 5사이즈 조회. DB엔 문의 데이터 총 8개 존재.
+        Member member = Member.builder()
+                .userId("member4")
+                .name("ddd")
+                .email("d@d.com")
+                .password("111")
+                .phone("010-1234-5678")
+                .avatarImage("ddd.png")
+                .role(Role.ADMIN)
+                .build();
+        memberRepository.save(member);
+        InquiryPageRequestDTO inquiryPageRequestDTO = InquiryPageRequestDTO.builder().pageNumber(2).build();
+
+        Page<InquiryResponseDTO> inquiriesAdmin =
+                inquiryService.getInquiriesByMemberRole(member.getMemberId(), inquiryPageRequestDTO);
+
+        assertNotNull(inquiriesAdmin);
+        assertEquals(8, inquiriesAdmin.getTotalElements());
+        assertEquals(2, inquiriesAdmin.getTotalPages());
+        assertEquals(1, inquiriesAdmin.getNumber());
+        assertEquals(5, inquiriesAdmin.getSize());
+        assertEquals(3, inquiriesAdmin.getContent().size());
+    }
+
+    @Test
+    @DisplayName("USER 등록한 1:1 문의 전체 조회")
+    void testFindAllForUser() throws Exception {
+        // 2페이지 5사이즈 조회. DB엔 memberId = 1로 문의 데이터 총 7개 존재.
+        Long memberId = 1L;
+        InquiryPageRequestDTO inquiryPageRequestDTO = InquiryPageRequestDTO.builder().pageNumber(2).build();
+
+        Page<InquiryResponseDTO> inquiriesUser =
+                inquiryService.getInquiriesByMemberRole(memberId, inquiryPageRequestDTO);
+
+        assertNotNull(inquiriesUser);
+        assertEquals(7, inquiriesUser.getTotalElements());
+        assertEquals(2, inquiriesUser.getTotalPages());
+        assertEquals(1, inquiriesUser.getNumber());
+        assertEquals(5, inquiriesUser.getSize());
+        assertEquals(2, inquiriesUser.getContent().size());
+    }
+}


### PR DESCRIPTION
## 📌 과제 설명 

#32 USER 회원 또는 ADMIN 회원에 따라 1:1 문의를 등록하고 조회할 수 있는 기능 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

1. USER 회원 1:1 문의 등록
    - 회원의 memberId를 담아 회원 정보를 조회한 뒤, 회원 정보까지 담아 1:1 문의에 등록
    - 로그인 기능 추가 시 수정 필요!
2. 모든 회원 1:1 문의 단건 조회
    - 문의의 inquiryId를 받아 해당 1:1 문의 정보 반환
3. USER 회원 1:1 문의 리스트 페이징을 위한 Querydsl 설정 추가
4. ADMIN/USER 회원 종류에 따른 1:1 문의 리스트 페이징
    - ADMIN인 경우, 모든 회원이 등록한 1:1 문의 리스트 반환
    - USER인 경우, 해당 memberId로 등록한 1:1 문의 리스트 반환
    - 로그인 기능 추가 시 수정 필요!
5. 서비스, 레포지토리에 대한 테스트 케이스 완료


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
