### PR TITLE
refactor: 청원 컨트롤러 사용 인증 필요없는 조회 기능들에 대한 필터링 제거

### DIFF
--- a/src/main/java/com/example/echo/domain/petition/controller/PetitionCrawlController.java
+++ b/src/main/java/com/example/echo/domain/petition/controller/PetitionCrawlController.java
@@ -5,7 +5,10 @@ import com.example.echo.domain.petition.service.PetitionCrawlService;
 import com.example.echo.global.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
+
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class PetitionCrawlController {
 
     private final PetitionCrawlService petitionCrawlService;
+
+    @Value("${webdriver.chrome.driver}")
+    private String chromeDriverPath;
+
+    @PostConstruct
+    public void init() {
+        System.setProperty("webdriver.chrome.driver", chromeDriverPath);
+    }
 
     //상세페이지 이동 가능한 리스트 크롤링
     @Operation(summary = "상세페이지 이동 가능한 리스트 크롤링", description = "청원 상세페이지로 이동할 수 있는 리스트를 크롤링합니다.")

--- a/src/main/java/com/example/echo/domain/petition/service/PetitionCrawlService.java
+++ b/src/main/java/com/example/echo/domain/petition/service/PetitionCrawlService.java
@@ -45,9 +45,7 @@ public class PetitionCrawlService {
     //title, href 이런 것들 따로 리스트에 저장한 뒤에
     //petition 다시 돌면서 href 같이 돌면서 들어가서 정보 가져오기
     public List<PetitionCrawl> dynamicCrawl(Long id, String url) {
-        // ChromeDriver 주소
-        System.setProperty("webdriver.chrome.driver", "C:/webprac/chromedriverwin32/chromedriver.exe");
-        // 옵셜 설정
+        // 옵션 설정
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless");
 

--- a/src/main/java/com/example/echo/global/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/example/echo/global/security/filter/JWTCheckFilter.java
@@ -29,7 +29,7 @@ public class JWTCheckFilter extends OncePerRequestFilter {
     // 필터링 적용하지 않을 URI 체크
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return isAuthExcludedPath(request.getRequestURI()); // 토큰 발급 경로는 제외
+        return isAuthExcludedPath(request); // 토큰 발급 경로는 제외
     }
 
     // 필터링 적용 - 액세스 토큰 확인
@@ -57,8 +57,21 @@ public class JWTCheckFilter extends OncePerRequestFilter {
     }
 
     // 특정 URI가 인증 제외 경로인지 확인
-    private boolean isAuthExcludedPath(String requestURI) {
-        return requestURI.startsWith("/api/members/login") || requestURI.startsWith("/api/members/signup");
+    private boolean isAuthExcludedPath(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        String method = request.getMethod();
+
+        // 회원 가입/로그인 경로 인증 제외
+        if (requestURI.startsWith("/api/members/login") || requestURI.startsWith("/api/members/signup")) {
+            return true;
+        }
+
+        // 청원 단건/전체/만료일순 조회(GET)는 인증 제외
+        if (requestURI.startsWith("/api/petitions") && "GET".equalsIgnoreCase(method)) {
+            return true;
+        }
+
+        return false;
     }
 
     // 액세스 토큰 유효성 검사


### PR DESCRIPTION
## 📌 과제 설명

청원 컨트롤러에서 비회원도 접근할 수 있는 청원 조회 기능들에 대한 필터링 제거

## 👩‍💻 요구 사항과 구현 내용 

1. 크롤링 코드에서 개인 로컬 환경마다 다른 chromedriver 경로를 제거했습니다.
    - *중요: 반드시 개인 application-db.properties 파일에 해당 설정 추가. 노션 보드의 "크롤링" 참고!!!
2. 청원 조회에서 상세/전체/만료일순/동의자순 기능들에 대한 인증 제거했습니다.

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 크롤링 시 반드시 application-db.properties 파일에 해당 설정 추가!!