### PR TITLE
refactor: 청원 기간이 남은 데이터만 조회

### DIFF
--- a/src/main/java/com/example/echo/domain/petition/controller/PetitionController.java
+++ b/src/main/java/com/example/echo/domain/petition/controller/PetitionController.java
@@ -48,9 +48,8 @@ public class PetitionController {
     // 청원 전체 조회
     @Operation(summary = "청원 전체 조회", description = "모든 청원을 페이지별로 조회합니다.")
     @GetMapping
-
     public ResponseEntity<Page<PetitionResponseDto>> getPetitions(Pageable pageable) {
-        Page<PetitionResponseDto> petitions = petitionService.getPetitions(pageable);
+        Page<PetitionResponseDto> petitions = petitionService.getOngoingPetitions(pageable);
         return ResponseEntity.ok(petitions);
     }
 
@@ -151,7 +150,7 @@ public class PetitionController {
     }
 
 
-    //나의 관심 목록 조회
+    // 나의 관심 목록 조회
     @PreAuthorize("hasRole('USER')" )
     @GetMapping("/Myinterest")
     public ResponseEntity<?> getInterestList(@AuthenticationPrincipal Member member) {
@@ -164,7 +163,7 @@ public class PetitionController {
         }
     }
 
-    // 관심 목록 수에따라 정렬
+    // 관심 목록 수에 따라 정렬
     @GetMapping("/interests")
     public ResponseEntity<?> getPetitionsByInterestCount() {
         try {

--- a/src/main/java/com/example/echo/domain/petition/repository/PetitionRepository.java
+++ b/src/main/java/com/example/echo/domain/petition/repository/PetitionRepository.java
@@ -1,34 +1,36 @@
 package com.example.echo.domain.petition.repository;
 
-import com.example.echo.domain.petition.entity.Category;
 import com.example.echo.domain.petition.dto.response.PetitionResponseDto;
+import com.example.echo.domain.petition.entity.Category;
 import com.example.echo.domain.petition.entity.Petition;
-import java.util.List;
-import java.util.Optional;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface PetitionRepository extends JpaRepository<Petition, Long> {
+    @Query("SELECT p FROM Petition p WHERE p.category = :category AND p.endDate >= CURRENT_TIMESTAMP")
     Page<Petition> findByCategory(Pageable pageable, Category category);
 
     @Query("SELECT p FROM Petition p WHERE p.originalUrl = :originalUrl")
     Optional<Petition> findByUrl(@Param("originalUrl") String originUrl);
 
-    @Query("SELECT p FROM Petition p ORDER BY p.endDate ASC")
+    @Query("SELECT p FROM Petition p WHERE p.endDate >= CURRENT_TIMESTAMP ORDER BY p.endDate ASC")
     List<PetitionResponseDto> getEndDatePetitions(Pageable pageable);
 
-    @Query("SELECT p FROM Petition p ORDER BY p.likesCount DESC")
+    @Query("SELECT p FROM Petition p WHERE p.endDate >= CURRENT_TIMESTAMP ORDER BY p.likesCount DESC")
     List<PetitionResponseDto> getLikesCountPetitions(Pageable pageable);
 
-    @Query("SELECT p FROM Petition p WHERE p.category = :category ORDER BY FUNCTION('RAND')")
+    @Query("SELECT p FROM Petition p WHERE p.category = :category AND p.endDate >= CURRENT_TIMESTAMP ORDER BY FUNCTION('RAND')")
     List<PetitionResponseDto> getCategoryPetitionsInRandomOrder(@Param("category") Category category, Pageable pageable);
 
     // 제목에 검색어가 포함된 청원 조회 메서드 추가
     List<Petition> findByTitleContainingIgnoreCase(String title);
 
+    @Query("SELECT p FROM Petition p WHERE p.endDate >= CURRENT_TIMESTAMP")
+    Page<Petition> findAllOngoing(Pageable pageable);
 }

--- a/src/main/java/com/example/echo/domain/petition/service/PetitionService.java
+++ b/src/main/java/com/example/echo/domain/petition/service/PetitionService.java
@@ -15,7 +15,7 @@ import com.example.echo.domain.petition.exception.PetitionNotFoundException;
 import com.example.echo.domain.petition.repository.PetitionRepository;
 import com.example.echo.global.exception.ErrorCode;
 import com.example.echo.global.exception.PetitionCustomException;
-import java.time.LocalDate;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -82,6 +82,11 @@ public class PetitionService {
     // 청원 전체 조회
     public Page<PetitionResponseDto> getPetitions(Pageable pageable) {
         return petitionRepository.findAll(pageable).map(PetitionResponseDto::new);
+    }
+
+    // 진행 중인 청원 전체 조회
+    public Page<PetitionResponseDto> getOngoingPetitions(Pageable pageable) {
+        return petitionRepository.findAllOngoing(pageable).map(PetitionResponseDto::new);
     }
 
     // 청원 전체 조회 (카테고리별)


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

프론트에서 연결된 청원 기간이 지난 데이터도 조회되던 모든 기능들에 대해 진행 중인 청원만 조회되도록 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

- 청원 전체 조회 기능의 서비스/레포지토리 메서드 변경
- 좋아요 순 5개 청원 조회 레포지토리 쿼리 변경
- 가까운 만료일 순 5개 청원 조회 레포지토리 쿼리 변경
- 카테고리 별 랜덤 5개 청원 조회 레포지토리 쿼리 변경
- 카테고리 별 전체 조회 레포지토리 쿼리 변경

프론트엔드 테스트 완료