### PR TITLE
fix: 관심목록 JWT 인증 로직 수정

### DIFF
--- a/src/main/java/com/example/echo/domain/interest/entity/Interest.java
+++ b/src/main/java/com/example/echo/domain/interest/entity/Interest.java
@@ -1,29 +1,29 @@
-//package com.example.echo.domain.interest.entity;
-//
-//import com.example.echo.domain.member.entity.Member;
-//import com.example.echo.domain.petition.entity.Petition;
-//import jakarta.persistence.*;
-//import lombok.*;
-//
-//@Entity
-//@Table(name = "interest")
-//@ToString
-//@Getter
-//@NoArgsConstructor
-//@AllArgsConstructor
-//@Builder
-//public class Interest {
-//
-//    @Id
-//    @GeneratedValue(strategy = GenerationType.IDENTITY)
-//    @Column(name = "interest_id", nullable = false, unique = true)
-//    private Long interestId;
-//
-//    @ManyToOne
-//    @JoinColumn(name = "petition_id", nullable = false)
-//    private Petition petition;  // 청원 필드 추가. N:1 연결
-//
-//    @ManyToOne
-//    @JoinColumn(name = "member_id", nullable = false)
-//    private Member member;
-//}
+package com.example.echo.domain.interest.entity;
+
+import com.example.echo.domain.member.entity.Member;
+import com.example.echo.domain.petition.entity.Petition;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "interest")
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Interest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "interest_id", nullable = false, unique = true)
+    private Long interestId;
+
+    @ManyToOne
+    @JoinColumn(name = "petition_id", nullable = false)
+    private Petition petition;  // 청원 필드 추가. N:1 연결
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/example/echo/domain/petition/controller/PetitionController.java
+++ b/src/main/java/com/example/echo/domain/petition/controller/PetitionController.java
@@ -1,6 +1,7 @@
 package com.example.echo.domain.petition.controller;
 
 import com.example.echo.domain.member.entity.Member;
+import com.example.echo.domain.member.repository.MemberRepository;
 import com.example.echo.domain.petition.dto.request.InterestRequestDTO;
 import com.example.echo.domain.petition.dto.request.PetitionRequestDto;
 import com.example.echo.domain.petition.dto.response.InterestPetitionResponseDTO;
@@ -8,6 +9,7 @@ import com.example.echo.domain.petition.dto.response.PetitionDetailResponseDto;
 import com.example.echo.domain.petition.dto.response.PetitionResponseDto;
 import com.example.echo.domain.petition.entity.Category;
 import com.example.echo.domain.petition.service.PetitionService;
+import com.example.echo.global.security.auth.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 public class PetitionController {
 
     private final PetitionService petitionService;
+    private final MemberRepository memberRepository;
 
     // 청원 등록
     @PreAuthorize("hasRole('ADMIN')")
@@ -151,9 +154,11 @@ public class PetitionController {
 
 
     // 나의 관심 목록 조회
-    @PreAuthorize("hasRole('USER')" )
+    @PreAuthorize("isAuthenticated()") // 메서드에 대한 접근을 인증된 사용자에게만 허용
     @GetMapping("/Myinterest")
-    public ResponseEntity<?> getInterestList(@AuthenticationPrincipal Member member) {
+    public ResponseEntity<?> getInterestList(@AuthenticationPrincipal CustomUserPrincipal principal) {
+        Member member = memberRepository.findById(principal.getMemberId())
+                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
         try {
             // 회원의 관심 목록 조회
             List<InterestPetitionResponseDTO> interestList = petitionService.getInterestList(member);

--- a/src/main/java/com/example/echo/global/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/example/echo/global/security/filter/JWTCheckFilter.java
@@ -71,9 +71,9 @@ public class JWTCheckFilter extends OncePerRequestFilter {
             return true;
         }
 
-        // 청원 단건/전체/만료일순 조회(GET)는 인증 제외
+        // 청원 관련 GET 요청 중 /api/petitions/Myinterest를 제외한 모든 요청은 인증 제외
         if (requestURI.startsWith("/api/petitions") && "GET".equalsIgnoreCase(method)) {
-            return true;
+            return !requestURI.equals("/api/petitions/Myinterest");
         }
 
         return false;

--- a/src/main/java/com/example/echo/global/security/filter/JWTCheckFilter.java
+++ b/src/main/java/com/example/echo/global/security/filter/JWTCheckFilter.java
@@ -73,7 +73,7 @@ public class JWTCheckFilter extends OncePerRequestFilter {
 
         // 청원 관련 GET 요청 중 /api/petitions/Myinterest를 제외한 모든 요청은 인증 제외
         if (requestURI.startsWith("/api/petitions") && "GET".equalsIgnoreCase(method)) {
-            return !requestURI.equals("/api/petitions/Myinterest");
+            return !requestURI.equals("/api/petitions/Myinterest"); // /api/petitions/Myinterest 경로일 경우 인증 요구 (false 반환)
         }
 
         return false;


### PR DESCRIPTION

## 📌 과제 설명
#116 fix: 관심목록 JWT 인증 로직 수정
## 👩‍💻 요구 사항과 구현 내용
- 관심목록 조회의 경우 인증이 필요하나 JWTCheckFilter에서 청원 관련 HTTP 'GET' 메서드에 대해 인증을 우회하도록 설정되어있어 액세스 거부 오류 발생
  - 관심목록 조회는 인증 우회 목록에서 제외하여 오류 해결
  - 액세스 토큰으로 회원 구분
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
